### PR TITLE
Refactor: use data-test-id to find delete and edit button

### DIFF
--- a/lib/botd_web/controllers/person_html/show.html.heex
+++ b/lib/botd_web/controllers/person_html/show.html.heex
@@ -5,7 +5,7 @@
       <.button>Back to people</.button>
     </.link>
     <%= if @current_user do %>
-      <.link href={~p"/people/#{@person}/edit"}>
+      <.link href={~p"/people/#{@person}/edit"} data-test-id="edit-person">
         <.button>
           <.icon name="hero-pencil" class="h-5 w-5 mr-2" /> Edit
         </.button>
@@ -14,6 +14,7 @@
         href={~p"/people/#{@person}"}
         method="delete"
         data-confirm="Are you sure you want to delete this person? This action cannot be undone."
+        data-test-id="remove-person"
       >
         <.button class="bg-red-600 hover:bg-red-700">
           <.icon name="hero-trash" class="h-5 w-5" />

--- a/test/botd_web/controllers/person_html_test.exs
+++ b/test/botd_web/controllers/person_html_test.exs
@@ -26,7 +26,7 @@ defmodule BotdWeb.PersonHTMLTest do
   end
 
   describe "Person show.html" do
-    test "hide Edit and Delete buttons for authenticated users", %{
+    test "hide Edit and Delete buttons for unauthenticated users", %{
       conn: conn,
       person: person
     } do
@@ -37,10 +37,10 @@ defmodule BotdWeb.PersonHTMLTest do
       html = html_response(conn, 200)
       {:ok, document} = Floki.parse_document(html)
 
-      edit_button = Floki.find(document, "a[href*='/edit']")
+      edit_button = Floki.find(document, "[data-test-id='edit-person']")
       assert edit_button == []
 
-      delete_button = Floki.find(document, "a[data-method='delete']")
+      delete_button = Floki.find(document, "[data-test-id='remove-person']")
       assert delete_button == []
     end
 
@@ -59,10 +59,10 @@ defmodule BotdWeb.PersonHTMLTest do
       html = html_response(conn, 200)
       {:ok, document} = Floki.parse_document(html)
 
-      edit_button = Floki.find(document, "a[href$='/edit']")
+      edit_button = Floki.find(document, "[data-test-id='edit-person']")
       assert edit_button != []
 
-      delete_button = Floki.find(document, "a[data-confirm]")
+      delete_button = Floki.find(document, "[data-test-id='remove-person']")
       assert delete_button != []
     end
   end


### PR DESCRIPTION
With "Benutze data-test-id Selektor mit Floki.find" prompt