### PR TITLE
Refactor: prepare database and code for easier suggestions logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ npm-debug.log
 /assets/node_modules/
 
 .idea/
+backup.sql

--- a/README.md
+++ b/README.md
@@ -49,6 +49,41 @@ user = Repo.get_by(User, email: "user@example.com")
 {:ok, _updated_user} = user |> Ecto.Changeset.change(role: :admin) |> Repo.update()
 ```
 
+## PostgreSQL
+
+### Commands
+
+```
+\dt                             # check tables
+\d table_name                   # check columns
+\dT+ activity_logs_entity_type  # check enum values
+```
+
+### Backup and restore local database
+
+#### Connect to the database
+
+If the database name is `botd_dev` and username is `postgres`
+
+```
+psql -d botd_dev
+```
+
+#### How to Backup
+
+```
+pg_dump -U postgres -h localhost -p 5432 botd_dev > backup.sql
+
+```
+
+#### How to restore
+
+```
+dropdb -U postgres botd_dev
+createdb -U postgres botd_dev
+psql -U postgres -d botd_dev < backup.sql
+```
+
 ## Learn more
 
 - Official website: https://www.phoenixframework.org/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ mix compile
 mix ecto.migrate
 ```
 
+### Rollback one migration
+
+```
+mix ecto.rollback
+```
+
+or with -n option for many
+
 ### How to update user to :admin?
 
 In the terminal `iex -S mix`

--- a/lib/botd/activity_logs.ex
+++ b/lib/botd/activity_logs.ex
@@ -37,17 +37,31 @@ defmodule Botd.ActivityLogs do
     |> Repo.insert()
   end
 
-  def log_person_action(action, person, user) when action in [:create, :edit, :remove] do
-    user_info = if user, do: %{user_id: user.id, user_email: user.email}, else: %{}
-
+  def log_person_action(action, person, user)
+      when action in [:create_person, :create_person_via_suggestion, :edit_person, :remove_person] do
     attrs =
       %{
         action: action,
         entity_type: "person",
         entity_id: person.id,
-        entity_name: person.name
+        user_id: user.id
       }
-      |> Map.merge(user_info)
+
+    create_activity_log(attrs)
+  end
+
+  # Question to Samu: can I have suggestion type somehow? if i type suggestion. -> it should suggest me user autocomplete
+  def log_suggestion_action(action, suggestion)
+      when action in [:approve_suggestion, :reject_suggestion] do
+    user = suggestion.user
+
+    attrs =
+      %{
+        action: action,
+        entity_type: "suggestion",
+        entity_id: suggestion.id,
+        user_id: user.id
+      }
 
     create_activity_log(attrs)
   end

--- a/lib/botd/activity_logs.ex
+++ b/lib/botd/activity_logs.ex
@@ -50,7 +50,8 @@ defmodule Botd.ActivityLogs do
     create_activity_log(attrs)
   end
 
-  # Question to Samu: can I have suggestion type somehow? if i type suggestion. -> it should suggest me user autocomplete
+  # Question to Samu: can I have suggestion type somehow?
+  # if i type suggestion. -> it should suggest me user autocomplete
   def log_suggestion_action(action, suggestion)
       when action in [:approve_suggestion, :reject_suggestion] do
     user = suggestion.user

--- a/lib/botd/activity_logs/activity_log.ex
+++ b/lib/botd/activity_logs/activity_log.ex
@@ -14,12 +14,10 @@ defmodule Botd.ActivityLogs.ActivityLog do
   import Ecto.Changeset
 
   schema "activity_logs" do
-    field :action, Ecto.Enum, values: [:create, :edit, :remove]
-    field :entity_type, :string
+    field :action, :string
     field :entity_id, :integer
-    field :entity_name, :string
     field :user_id, :integer
-    field :user_email, :string
+    field :entity_type, :string
 
     timestamps()
   end

--- a/lib/botd/activity_logs/activity_log.ex
+++ b/lib/botd/activity_logs/activity_log.ex
@@ -13,21 +13,33 @@ defmodule Botd.ActivityLogs.ActivityLog do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @actions [
+    :create_person,
+    :create_person_via_suggestion,
+    :edit_person,
+    :remove_person,
+    :create_suggestion,
+    :edit_suggestion,
+    :remove_suggestion,
+    :approve_suggestion,
+    :reject_suggestion
+  ]
   @entity_types [:person, :suggestion]
 
   schema "activity_logs" do
-    field :action, :string
+    field :action, Ecto.Enum, values: @actions
     field :entity_id, :integer
-    field :user_id, :integer
     field :entity_type, Ecto.Enum, values: @entity_types
+    field :user_id, :integer
 
     timestamps()
   end
 
   def changeset(activity_log, attrs) do
     activity_log
-    |> cast(attrs, [:action, :entity_type, :entity_id, :entity_name, :user_id, :user_email])
-    |> validate_required([:action, :entity_type, :entity_id, :entity_name])
+    |> cast(attrs, [:action, :entity_id, :entity_type, :user_id])
+    |> validate_required([:action, :entity_type, :entity_id, :user_id])
     |> validate_inclusion(:entity_type, @entity_types)
+    |> validate_inclusion(:action, @actions)
   end
 end

--- a/lib/botd/activity_logs/activity_log.ex
+++ b/lib/botd/activity_logs/activity_log.ex
@@ -13,11 +13,13 @@ defmodule Botd.ActivityLogs.ActivityLog do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @entity_types [:person, :suggestion]
+
   schema "activity_logs" do
     field :action, :string
     field :entity_id, :integer
     field :user_id, :integer
-    field :entity_type, :string
+    field :entity_type, Ecto.Enum, values: @entity_types
 
     timestamps()
   end
@@ -26,5 +28,6 @@ defmodule Botd.ActivityLogs.ActivityLog do
     activity_log
     |> cast(attrs, [:action, :entity_type, :entity_id, :entity_name, :user_id, :user_email])
     |> validate_required([:action, :entity_type, :entity_id, :entity_name])
+    |> validate_inclusion(:entity_type, @entity_types)
   end
 end

--- a/lib/botd/suggestions/suggestion.ex
+++ b/lib/botd/suggestions/suggestion.ex
@@ -6,11 +6,6 @@ defmodule Botd.Suggestions.Suggestion do
   for new people to be added to the Book of the Dead. It includes fields
   for the suggested person's information, the status of the suggestion,
   and tracking of who submitted and reviewed it.
-
-  Suggestions can have one of three statuses:
-  - pending: awaiting moderator review
-  - approved: accepted and converted to a person record
-  - rejected: declined by a moderator with optional notes
   """
 
   use Ecto.Schema

--- a/lib/botd_web/controllers/activity_log_html/index.html.heex
+++ b/lib/botd_web/controllers/activity_log_html/index.html.heex
@@ -3,11 +3,10 @@
 </.header>
 
 <.table id="activity_logs" rows={@activity_logs}>
-  <:col :let={log} label="User">{log.user_email}</:col>
+  <:col :let={log} label="User">{log.user_id}</:col>
   <:col :let={log} label="Action">
     <span class={action_color(log.action)}>{format_action(log.action)}</span>
   </:col>
-  <:col :let={log} label="Entity">{log.entity_name}</:col>
   <:col :let={log} label="Type">{log.entity_type}</:col>
   <:col :let={log} label="When">{format_timestamp(log.inserted_at)}</:col>
 </.table>

--- a/lib/botd_web/controllers/page_html/home.html.heex
+++ b/lib/botd_web/controllers/page_html/home.html.heex
@@ -33,15 +33,25 @@
     >
       <.icon name="hero-book-open" class="w-6 h-6 mr-2" /> Read the book
     </.link>
-    
-<!-- Admin link for logged in users -->
+
     <%= if admin?(@conn) do %>
       <div class="mt-4">
         <.link
           href={~p"/admin/logs"}
           class="text-gray-400 hover:text-amber-400 transition-colors duration-300"
         >
-          <.icon name="hero-clock" class="w-4 h-4 inline mr-1" /> Activity Logs
+          <.icon name="hero-clock" class="w-4 h-4 inline mr-1" />Activity Logs
+        </.link>
+      </div>
+    <% end %>
+
+    <%= if moderator_or_admin?(@conn) do %>
+      <div class="mt-4">
+        <.link
+          href={~p"/protected/suggestions"}
+          class="text-gray-400 hover:text-amber-400 transition-colors duration-300"
+        >
+          <.icon name="hero-clipboard-document-list" class="w-4 h-4 inline mr-1" />Suggestions
         </.link>
       </div>
     <% end %>

--- a/priv/repo/migrations/20250417133145_conver_entity_type_to_enum.exs
+++ b/priv/repo/migrations/20250417133145_conver_entity_type_to_enum.exs
@@ -1,0 +1,48 @@
+defmodule Botd.Repo.Migrations.ConvertEntityTypeToEnum do
+  use Ecto.Migration
+
+  def up do
+    # 1. Create enym type
+    execute("""
+    CREATE TYPE activity_logs_entity_type AS ENUM ('person', 'suggestion');
+    """)
+
+    # 2. temp enum column
+    alter table(:activity_logs) do
+      add :entity_type_tmp, :activity_logs_entity_type
+    end
+
+    # 3. copy data from string to enum
+    execute("""
+    UPDATE activity_logs
+    SET entity_type_tmp = entity_type::activity_logs_entity_type
+    """)
+
+    # 4. old table remove
+    alter table(:activity_logs) do
+      remove :entity_type
+    end
+
+    # 5. new enum column rename
+    rename table(:activity_logs), :entity_type_tmp, to: :entity_type
+  end
+
+  def down do
+    alter table(:activity_logs) do
+      add :entity_type_tmp, :string
+    end
+
+    execute("""
+    UPDATE activity_logs
+    SET entity_type_tmp = entity_type::text
+    """)
+
+    alter table(:activity_logs) do
+      remove :entity_type
+    end
+
+    rename table(:activity_logs), :entity_type, to: :entity_type_tmp
+
+    execute("DROP TYPE activity_logs_entity_type;")
+  end
+end

--- a/priv/repo/migrations/20250418102607_remove_email_and_name_from_activity_logs.exs
+++ b/priv/repo/migrations/20250418102607_remove_email_and_name_from_activity_logs.exs
@@ -1,0 +1,10 @@
+defmodule Botd.Repo.Migrations.RemoveEmailAndNameFromActivityLogs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:activity_logs) do
+      remove :user_email
+      remove :entity_name
+    end
+  end
+end

--- a/priv/repo/migrations/20250418102610_update_entity_type_string_values_in_activity_logs.exs
+++ b/priv/repo/migrations/20250418102610_update_entity_type_string_values_in_activity_logs.exs
@@ -1,0 +1,43 @@
+defmodule Botd.Repo.Migrations.UpdateEntityTypeStringValuesInActivityLogs do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    UPDATE activity_logs
+    SET action = 'create_person'
+    WHERE action = 'create';
+    """
+
+    execute """
+    UPDATE activity_logs
+    SET action = 'edit_person'
+    WHERE action = 'edit';
+    """
+
+    execute """
+    UPDATE activity_logs
+    SET action = 'remove_person'
+    WHERE action = 'remove';
+    """
+  end
+
+  def down do
+    execute """
+    UPDATE activity_logs
+    SET action = 'create'
+    WHERE action = 'create_person';
+    """
+
+    execute """
+    UPDATE activity_logs
+    SET action = 'edit'
+    WHERE action = 'edit_person';
+    """
+
+    execute """
+    UPDATE activity_logs
+    SET action = 'remove'
+    WHERE action = 'remove_person';
+    """
+  end
+end

--- a/priv/repo/migrations/20250418124719_activity_log_action_to_enum.exs
+++ b/priv/repo/migrations/20250418124719_activity_log_action_to_enum.exs
@@ -1,18 +1,6 @@
 defmodule Botd.Repo.Migrations.ActivityLogActionToEnum do
   use Ecto.Migration
 
-  # @actions [
-  #   :create_person,
-  #   :create_person_via_suggestion,
-  #   :edit_person,
-  #   :remove_person,
-  #   :create_suggestion,
-  #   :edit_suggestion,
-  #   :remove_suggestion,
-  #   :approve_suggestion,
-  #   :reject_suggestion
-  # ]
-
   def up do
     # make new enum
     execute """

--- a/priv/repo/migrations/20250418124719_activity_log_action_to_enum.exs
+++ b/priv/repo/migrations/20250418124719_activity_log_action_to_enum.exs
@@ -1,0 +1,63 @@
+defmodule Botd.Repo.Migrations.ActivityLogActionToEnum do
+  use Ecto.Migration
+
+  # @actions [
+  #   :create_person,
+  #   :create_person_via_suggestion,
+  #   :edit_person,
+  #   :remove_person,
+  #   :create_suggestion,
+  #   :edit_suggestion,
+  #   :remove_suggestion,
+  #   :approve_suggestion,
+  #   :reject_suggestion
+  # ]
+
+  def up do
+    # make new enum
+    execute """
+    CREATE TYPE activity_logs_action_type AS ENUM ('create_person', 'create_person_via_suggestion', 'edit_person', 'remove_person', 'create_suggestion', 'edit_suggestion', 'remove_suggestion', 'approve_suggestion', 'reject_suggestion');
+    """
+
+    # temp column create
+    alter table(:activity_logs) do
+      add :action_new, :activity_logs_action_type
+    end
+
+    # Data from old column to new column
+    execute """
+    UPDATE activity_logs
+    SET action_new = action::activity_logs_action_type
+    """
+
+    # 4. Old column remove, new column rename
+    alter table(:activity_logs) do
+      remove :action
+    end
+
+    rename table(:activity_logs), :action_new, to: :action
+  end
+
+  def down do
+    alter table(:activity_logs) do
+      add :action_old, :string
+    end
+
+    # Data from Enum to string
+    execute """
+    UPDATE activity_logs
+    SET action_old = action::text
+    """
+
+    alter table(:activity_logs) do
+      remove :action
+    end
+
+    rename table(:activity_logs), :action_old, to: :action
+
+    # Enum type drop
+    execute """
+    DROP TYPE activity_logs_action_type;
+    """
+  end
+end

--- a/test/botd/activity_logs_test.exs
+++ b/test/botd/activity_logs_test.exs
@@ -26,19 +26,19 @@ defmodule Botd.ActivityLogsTest do
         })
         |> Repo.insert()
 
-      # suggestion =
-      #   %Suggestion{
-      #     id: 1,
-      #     name: "Test Suggestion",
-      #     death_date: ~D[2023-01-01],
-      #     place: "Test City",
-      #     status: :pending,
-      #     user_id: user.id
-      #   }
-      #   |> Repo.insert!()
+      suggestion =
+        %Suggestion{
+          id: 1,
+          name: "Test Suggestion",
+          death_date: ~D[2023-01-01],
+          place: "Test City",
+          status: :pending,
+          user: user
+        }
+        |> Repo.insert!()
 
       # %{user: user, person: person, suggestion: suggestion}
-      %{user: user, person: person}
+      %{user: user, person: person, suggestion: suggestion}
     end
 
     test "list_activity_logs/0 returns all activity logs ordered by insertion date", %{
@@ -105,19 +105,18 @@ defmodule Botd.ActivityLogsTest do
       end
     end
 
-    # test "log_suggestion_action/3 logs actions for a suggestion", %{
-    #   user: user,
-    #   suggestion: suggestion
-    # } do
-    #   actions = [:approve_suggestion, :reject_suggestion]
+    test "log_suggestion_action/3 logs actions for a suggestion", %{
+      suggestion: suggestion
+    } do
+      actions = [:approve_suggestion, :reject_suggestion]
 
-    #   for action <- actions do
-    #     {:ok, log} = ActivityLogs.log_suggestion_action(action, suggestion)
-    #     assert log.action == action
-    #     assert log.entity_type == :suggestion
-    #     assert log.entity_id == suggestion.id
-    #     assert log.user_id == user.id
-    #   end
-    # end
+      for action <- actions do
+        {:ok, log} = ActivityLogs.log_suggestion_action(action, suggestion)
+        assert log.action == action
+        assert log.entity_type == :suggestion
+        assert log.entity_id == suggestion.id
+        assert log.user_id == suggestion.user.id
+      end
+    end
   end
 end

--- a/test/botd/activity_logs_test.exs
+++ b/test/botd/activity_logs_test.exs
@@ -1,0 +1,123 @@
+defmodule Botd.ActivityLogsTest do
+  use Botd.DataCase
+
+  alias Botd.ActivityLogs
+  alias Botd.People.Person
+  alias Botd.Repo
+  alias Botd.Suggestions.Suggestion
+  alias Botd.Users.User
+
+  describe "activity_logs" do
+    setup do
+      user =
+        %User{
+          id: 1,
+          email: "test@example.com",
+          role: :member
+        }
+        |> Repo.insert!()
+
+      {:ok, person} =
+        %Person{}
+        |> Person.changeset(%{
+          name: "Test Person",
+          death_date: ~D[2023-01-01],
+          place: "Test City"
+        })
+        |> Repo.insert()
+
+      # suggestion =
+      #   %Suggestion{
+      #     id: 1,
+      #     name: "Test Suggestion",
+      #     death_date: ~D[2023-01-01],
+      #     place: "Test City",
+      #     status: :pending,
+      #     user_id: user.id
+      #   }
+      #   |> Repo.insert!()
+
+      # %{user: user, person: person, suggestion: suggestion}
+      %{user: user, person: person}
+    end
+
+    test "list_activity_logs/0 returns all activity logs ordered by insertion date", %{
+      user: user,
+      person: person
+    } do
+      # Create some activity logs
+      {:ok, log1} = ActivityLogs.log_person_action(:create_person, person, user)
+      # Ensure logs have different timestamps
+      :timer.sleep(10)
+      {:ok, log2} = ActivityLogs.log_person_action(:edit_person, person, user)
+
+      logs = ActivityLogs.list_activity_logs()
+
+      assert length(logs) >= 2
+      assert Enum.find(logs, &(&1.id == log1.id))
+      assert Enum.find(logs, &(&1.id == log2.id))
+
+      # Verify order is newest first
+      first_two_logs = Enum.take(logs, 2)
+      [newer, older] = first_two_logs
+      assert newer.inserted_at >= older.inserted_at
+    end
+
+    test "get_activity_log!/1 returns the log with given id", %{user: user, person: person} do
+      {:ok, log} = ActivityLogs.log_person_action(:create_person, person, user)
+      retrieved_log = ActivityLogs.get_activity_log!(log.id)
+      assert retrieved_log.id == log.id
+      assert retrieved_log.action == :create_person
+      assert retrieved_log.entity_type == :person
+      assert retrieved_log.entity_id == person.id
+      assert retrieved_log.user_id == user.id
+    end
+
+    test "create_activity_log/1 creates a log with valid attributes" do
+      valid_attrs = %{
+        action: :create_person,
+        entity_type: :person,
+        entity_id: 42,
+        user_id: 1
+      }
+
+      {:ok, log} = ActivityLogs.create_activity_log(valid_attrs)
+      assert log.action == :create_person
+      assert log.entity_type == :person
+      assert log.entity_id == 42
+      assert log.user_id == 1
+    end
+
+    test "create_activity_log/1 returns error with invalid attributes" do
+      invalid_attrs = %{action: :invalid_action, entity_type: nil}
+      assert {:error, %Ecto.Changeset{}} = ActivityLogs.create_activity_log(invalid_attrs)
+    end
+
+    test "log_person_action/3 logs actions for a person", %{user: user, person: person} do
+      actions = [:create_person, :create_person_via_suggestion, :edit_person, :remove_person]
+
+      for action <- actions do
+        {:ok, log} = ActivityLogs.log_person_action(action, person, user)
+        assert log.action == action
+        assert log.entity_type == :person
+        assert log.entity_id == person.id
+        assert log.user_id == user.id
+      end
+    end
+
+    # test "log_suggestion_action/3 logs actions for a suggestion", %{
+    #   user: user,
+    #   suggestion: suggestion
+    # } do
+    #   actions = [:approve_suggestion, :reject_suggestion]
+
+    #   for action <- actions do
+    #     {:ok, log} = ActivityLogs.log_suggestion_action(action, suggestion)
+    #     assert log.action == action
+    #     assert log.entity_type == :suggestion
+    #     assert log.entity_id == suggestion.id
+    #     assert log.user_id == user.id
+    #   end
+    # end
+  end
+end


### PR DESCRIPTION
Refactor for activity_logs table:
- string to enum
- remove fields
- edit activiy logs index page accordingly

Adding, editing and removing person works + logged.
Suggestion has more tests, but suggestion logs not worked yet (due to wrong `:action`). The next PR will be about to fix it and improve visibility. Right now if logs did not create, the app is behaving silent.