### PR TITLE
Refactor: show schema error in UI

### DIFF
--- a/lib/botd_web.ex
+++ b/lib/botd_web.ex
@@ -45,6 +45,7 @@ defmodule BotdWeb do
       use Gettext, backend: BotdWeb.Gettext
 
       import Plug.Conn
+      import BotdWeb.ControllerHelpers
 
       unquote(verified_routes())
     end

--- a/lib/botd_web/controller_helpers.ex
+++ b/lib/botd_web/controller_helpers.ex
@@ -1,0 +1,19 @@
+defmodule BotdWeb.ControllerHelpers do
+  @moduledoc """
+  Helper functions shared across controllers.
+  """
+
+  @doc """
+  Converts a changeset's errors to a human-readable string.
+  """
+  def inspect_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+    |> Enum.map(fn {field, errors} ->
+      "#{field} #{Enum.join(errors, ", ")}"
+    end)
+  end
+end

--- a/lib/botd_web/controllers/person_controller.ex
+++ b/lib/botd_web/controllers/person_controller.ex
@@ -70,7 +70,6 @@ defmodule BotdWeb.PersonController do
 
   def delete(conn, %{"id" => id}) do
     person = People.get_person!(id)
-    {:ok, _person} = People.delete_person(person)
 
     user = conn.assigns[:current_user]
     ActivityLogs.log_person_action(:remove_person, person, user)
@@ -84,7 +83,7 @@ defmodule BotdWeb.PersonController do
       {:error, %Ecto.Changeset{} = changeset} ->
         conn
         |> put_flash(:error, inspect_errors(changeset))
-        |> redirect(to: ~p"/people/#{person}")
+        |> redirect(to: ~p"/people")
 
       {:error, _any_error} ->
         conn

--- a/lib/botd_web/controllers/person_controller.ex
+++ b/lib/botd_web/controllers/person_controller.ex
@@ -19,19 +19,19 @@ defmodule BotdWeb.PersonController do
 
     with {:ok, person} <- People.create_person(person_params),
          {:ok, _log} <- ActivityLogs.log_person_action(:create_person, person, user) do
-      # Success path
       conn
       |> put_flash(:info, "Person created successfully.")
       |> redirect(to: ~p"/people/#{person}")
     else
-      # Error paths
       {:error, %Ecto.Changeset{} = changeset} ->
-        render(conn, :new, changeset: changeset)
-
-      {:error, _log_error} ->
         conn
-        |> put_flash(:error, "Person was created but logging failed.")
-        |> render(:new, changeset: People.change_person(%Person{}))
+        |> put_flash(:error, inspect_errors(changeset))
+        |> redirect(to: ~p"/people/")
+
+      {:error, _any_error} ->
+        conn
+        |> put_flash(:error, "Person was created but with some errors.")
+        |> redirect(to: ~p"/people/")
     end
   end
 
@@ -48,18 +48,23 @@ defmodule BotdWeb.PersonController do
 
   def update(conn, %{"id" => id, "person" => person_params}) do
     person = People.get_person!(id)
+    user = conn.assigns[:current_user]
 
-    case People.update_person(person, person_params) do
-      {:ok, person} ->
-        user = conn.assigns[:current_user]
-        ActivityLogs.log_person_action(:edit_person, person, user)
-
+    with {:ok, updated_person} <- People.update_person(person, person_params),
+         {:ok, _log} <- ActivityLogs.log_person_action(:edit_person, updated_person, user) do
+      conn
+      |> put_flash(:info, "Person updated successfully.")
+      |> redirect(to: ~p"/people/#{updated_person}")
+    else
+      {:error, %Ecto.Changeset{} = changeset} ->
         conn
-        |> put_flash(:info, "Person updated successfully.")
+        |> put_flash(:error, inspect_errors(changeset))
         |> redirect(to: ~p"/people/#{person}")
 
-      {:error, %Ecto.Changeset{} = changeset} ->
-        render(conn, :edit, person: person, changeset: changeset)
+      {:error, _any_error} ->
+        conn
+        |> put_flash(:error, "Person was updated but with some errors.")
+        |> redirect(to: ~p"/people/#{person}")
     end
   end
 


### PR DESCRIPTION
AI would like to use this code:

```elixir
errors = Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
    Enum.reduce(opts, msg, fn {key, value}, acc ->
      String.replace(acc, "%{#{key}}", to_string(value))
    end)
  end)
```

the issue was `to_string(value)` does not work with `tuple`. This code is from 2019 book about `Programming Ecto`, page 68.

AI can't fix it with exact line and error message, it gives me another portion of wrong code again with same traverse + to_string.

In the [documentation](https://hexdocs.pm/ecto/Ecto.Changeset.html#traverse_errors/2-examples) we have new code:

```elixir
traverse_errors(changeset, fn {msg, opts} ->
  Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
    opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
  end)
end)
%{title: ["should be at least 3 characters"]}
```