### PR TITLE
Add: `:create_person_via_suggestion` works at activity logs

### DIFF
--- a/lib/botd/activity_logs.ex
+++ b/lib/botd/activity_logs.ex
@@ -54,14 +54,12 @@ defmodule Botd.ActivityLogs do
   # if i type suggestion. -> it should suggest me user autocomplete
   def log_suggestion_action(action, suggestion)
       when action in [:approve_suggestion, :reject_suggestion] do
-    user = suggestion.user
-
     attrs =
       %{
         action: action,
         entity_type: "suggestion",
         entity_id: suggestion.id,
-        user_id: user.id
+        user_id: suggestion.reviewed_by_id
       }
 
     create_activity_log(attrs)

--- a/test/botd/activity_logs_test.exs
+++ b/test/botd/activity_logs_test.exs
@@ -17,6 +17,14 @@ defmodule Botd.ActivityLogsTest do
         }
         |> Repo.insert!()
 
+      admin_user =
+        %User{
+          id: 2,
+          email: "admin@example.com",
+          role: :admin
+        }
+        |> Repo.insert!()
+
       {:ok, person} =
         %Person{}
         |> Person.changeset(%{
@@ -33,12 +41,13 @@ defmodule Botd.ActivityLogsTest do
           death_date: ~D[2023-01-01],
           place: "Test City",
           status: :pending,
-          user: user
+          user: user,
+          reviewed_by_id: admin_user.id
         }
         |> Repo.insert!()
 
       # %{user: user, person: person, suggestion: suggestion}
-      %{user: user, person: person, suggestion: suggestion}
+      %{user: user, person: person, suggestion: suggestion, admin_user: admin_user}
     end
 
     test "list_activity_logs/0 returns all activity logs ordered by insertion date", %{
@@ -105,8 +114,9 @@ defmodule Botd.ActivityLogsTest do
       end
     end
 
-    test "log_suggestion_action/3 logs actions for a suggestion", %{
-      suggestion: suggestion
+    test "log_suggestion_action/2 logs actions for a suggestion", %{
+      suggestion: suggestion,
+      admin_user: admin_user
     } do
       actions = [:approve_suggestion, :reject_suggestion]
 
@@ -115,7 +125,7 @@ defmodule Botd.ActivityLogsTest do
         assert log.action == action
         assert log.entity_type == :suggestion
         assert log.entity_id == suggestion.id
-        assert log.user_id == suggestion.user.id
+        assert log.user_id == admin_user.id
       end
     end
   end


### PR DESCRIPTION
Adding person via suggestion finally has own record in the activity log

TODO: improve tests scenarios, logs must be asserted

![Screenshot 2025-04-20 at 20 28 35](https://github.com/user-attachments/assets/5d4667e8-1779-4cc3-86a4-e2e4d1ec6088)
