### PR TITLE
Refactor: migrations for not null constraints + fix seed script

### DIFF
--- a/priv/repo/migrations/20250422160230_add_not_null_constraints_to_activity_logs.exs
+++ b/priv/repo/migrations/20250422160230_add_not_null_constraints_to_activity_logs.exs
@@ -1,0 +1,10 @@
+defmodule Botd.Repo.Migrations.AddNotNullConstraintsToActivityLogs do
+  use Ecto.Migration
+
+  def change do
+    execute "ALTER TABLE activity_logs ALTER COLUMN action SET NOT NULL"
+    execute "ALTER TABLE activity_logs ALTER COLUMN entity_id SET NOT NULL"
+    execute "ALTER TABLE activity_logs ALTER COLUMN entity_type SET NOT NULL"
+    execute "ALTER TABLE activity_logs ALTER COLUMN user_id SET NOT NULL"
+  end
+end

--- a/priv/repo/migrations/20250422160529_add_not_null_constraints_to_suggestions.exs
+++ b/priv/repo/migrations/20250422160529_add_not_null_constraints_to_suggestions.exs
@@ -1,0 +1,7 @@
+defmodule Botd.Repo.Migrations.AddNotNullConstraintsToSuggestions do
+  use Ecto.Migration
+
+  def change do
+    execute "ALTER TABLE suggestions ALTER COLUMN reviewed_by_id SET NOT NULL"
+  end
+end

--- a/priv/repo/migrations/20250423084034_remove_not_null_constraint_for_reviewed_by.exs
+++ b/priv/repo/migrations/20250423084034_remove_not_null_constraint_for_reviewed_by.exs
@@ -1,0 +1,7 @@
+defmodule Botd.Repo.Migrations.RemoveNotNullConstraintForReviewedBy do
+  use Ecto.Migration
+
+  def change do
+    execute "ALTER TABLE suggestions ALTER COLUMN reviewed_by_id DROP NOT NULL"
+  end
+end

--- a/priv/repo/seeds/movie_characters.exs
+++ b/priv/repo/seeds/movie_characters.exs
@@ -64,7 +64,7 @@ defmodule Botd.Seeds.MovieCharacters do
     case People.create_person(person_attrs) do
       {:ok, person} = result ->
         # Log the creation action
-        ActivityLogs.log_person_action(:create, person, user)
+        ActivityLogs.log_person_action(:create_person, person, user)
         IO.puts("Added person: #{person.name} (with activity log)")
         result
 


### PR DESCRIPTION
Some cleanup after AI, but with AI.

Check not null constraints in table, found 3 missing.
Update test
(forgotten from prev commits) - update seed script, it was outdated person action there.

![Screenshot 2025-04-22 at 18 03 58](https://github.com/user-attachments/assets/460de238-dbd1-4eef-8667-81be09f0b455)