### PR TITLE
Refactor: Chat module, simplify / cleanup

### DIFF
--- a/lib/botd/bot.ex
+++ b/lib/botd/bot.ex
@@ -97,7 +97,7 @@ defmodule Botd.Bot do
       chat_id = get_in(update, ["message", "chat", "id"])
       chat = Map.get(acc, chat_id, Chat.init_state())
 
-      new_chat_state = Chat.process_message_from_user(key, update, chat, chat_id)
+      new_chat_state = Chat.process_message_from_user(key, update, chat)
       Map.put(acc, chat_id, %Chat{new_chat_state | chat_id: chat_id})
     end)
   end

--- a/lib/botd/chat.ex
+++ b/lib/botd/chat.ex
@@ -7,6 +7,27 @@ defmodule Botd.Chat do
   alias Botd.Suggestions
   require Logger
 
+  @type step ::
+          :waiting_for_start
+          | :selected_action
+          | :selected_add_person
+          | :waiting_for_name
+          | :waiting_for_death_date
+          | :waiting_for_reason
+          | :waiting_for_photo
+          | :waiting_for_gallery_photos
+          | :finished
+
+  @type t :: %__MODULE__{
+          chat_id: integer(),
+          step: step(),
+          name: String.t() | nil,
+          death_date: Date.t() | nil,
+          reason: String.t() | nil,
+          photo_url: String.t() | nil,
+          photos: list()
+        }
+
   defstruct chat_id: nil,
             step: :waiting_for_start,
             name: nil,

--- a/lib/botd/chat.ex
+++ b/lib/botd/chat.ex
@@ -89,12 +89,17 @@ defmodule Botd.Chat do
 
   defp handle_waiting_for_death_date(key, update, chat) do
     death_date = get_in(update, ["message", "text"])
-    {:ok, parsed_date} = Date.from_iso8601(death_date)
-    next_step = make_next_step(:waiting_for_death_date)
 
-    answer_on_message(key, chat.chat_id, "Укажите причину")
+    case Date.from_iso8601(death_date) do
+      {:ok, parsed_date} ->
+        next_step = make_next_step(:waiting_for_death_date)
+        answer_on_message(key, chat.chat_id, "Укажите причину")
+        %__MODULE__{chat | step: next_step, death_date: parsed_date}
 
-    %__MODULE__{chat | step: next_step, death_date: parsed_date}
+      {:error, _} ->
+        answer_on_message(key, chat.chat_id, "Некорректная дата. Введите в формате YYYY-MM-DD.")
+        chat
+    end
   end
 
   defp handle_waiting_for_reason(key, update, chat) do

--- a/lib/botd/chat.ex
+++ b/lib/botd/chat.ex
@@ -30,12 +30,12 @@ defmodule Botd.Chat do
   }
   defp make_next_step(step), do: Map.get(@state_transitions, step, :finished)
 
-  defp handle_waiting_for_start(key, update, chat, chat_id) do
+  defp handle_waiting_for_start(key, update, chat) do
     text = get_in(update, ["message", "text"])
 
     if text == "/start" do
       Telegram.Api.request(key, "sendMessage",
-        chat_id: chat_id,
+        chat_id: chat.chat_id,
         text: "Выберите действие",
         reply_markup: {:json, start_menu()}
       )
@@ -44,51 +44,51 @@ defmodule Botd.Chat do
 
       %__MODULE__{chat | step: next_step}
     else
-      answer_on_message(key, chat_id, "Для начала работы введите /start")
+      answer_on_message(key, chat.chat_id, "Для начала работы введите /start")
 
       chat
     end
   end
 
-  defp handle_selected_action(key, update, chat, chat_id) do
+  defp handle_selected_action(key, update, chat) do
     text = get_in(update, ["message", "text"])
 
     if text == "Добавить" do
-      answer_on_message(key, chat_id, "Укажите имя")
+      answer_on_message(key, chat.chat_id, "Укажите имя")
       next_step = make_next_step(:selected_add_person)
       %__MODULE__{chat | step: next_step}
     else
-      answer_on_message(key, chat_id, "В данный момент доступно только добавление")
+      answer_on_message(key, chat.chat_id, "В данный момент доступно только добавление")
       chat
     end
   end
 
-  defp handle_waiting_for_name(key, update, chat, chat_id) do
+  defp handle_waiting_for_name(key, update, chat) do
     name = get_in(update, ["message", "text"])
     next_step = make_next_step(:waiting_for_name)
 
-    answer_on_message(key, chat_id, "Укажите дату смерти")
+    answer_on_message(key, chat.chat_id, "Укажите дату смерти")
 
     %__MODULE__{chat | step: next_step, name: name}
   end
 
-  defp handle_waiting_for_death_date(key, update, chat, chat_id) do
+  defp handle_waiting_for_death_date(key, update, chat) do
     death_date = get_in(update, ["message", "text"])
     {:ok, parsed_date} = Date.from_iso8601(death_date)
     next_step = make_next_step(:waiting_for_death_date)
 
-    answer_on_message(key, chat_id, "Укажите причину")
+    answer_on_message(key, chat.chat_id, "Укажите причину")
 
     %__MODULE__{chat | step: next_step, death_date: parsed_date}
   end
 
-  defp handle_waiting_for_reason(key, update, chat, chat_id) do
+  defp handle_waiting_for_reason(key, update, chat) do
     reason = get_in(update, ["message", "text"])
     next_step = make_next_step(:waiting_for_reason)
 
     answer_on_message(
       key,
-      chat_id,
+      chat.chat_id,
       "Добавьте одно фото на аватар (вы сможете добавить остальные фото на следующем шаге)"
     )
 
@@ -140,16 +140,16 @@ defmodule Botd.Chat do
     )
   end
 
-  defp handle_waiting_for_photo(key, update, chat, chat_id) do
+  defp handle_waiting_for_photo(key, update, chat) do
     with {:ok, file_id} <- handle_photo_message(update),
          {:ok, file_url} <- get_file_url(key, file_id),
          timestamp = DateTime.utc_now() |> DateTime.to_unix(),
          filename = "#{timestamp}_#{file_id}.jpg",
          {:ok, relative_path} <- Botd.FileHandler.download_and_save_file(file_url, filename) do
-      answer_on_message(key, chat_id, "Фото на аватар принято")
+      answer_on_message(key, chat.chat_id, "Фото на аватар принято")
 
       Telegram.Api.request(key, "sendMessage",
-        chat_id: chat_id,
+        chat_id: chat.chat_id,
         text:
           "Сейчас вы можете загрузить фото для фотогалереи. Можно загрузить несколько фото сразу.",
         reply_markup: {:json, photo_menu()}
@@ -160,21 +160,21 @@ defmodule Botd.Chat do
       %__MODULE__{chat | photo_url: relative_path, step: next_step}
     else
       {:error, reason} when reason == "No photo found" ->
-        answer_on_message(key, chat_id, "Кажется, вы не отправили фото.")
+        answer_on_message(key, chat.chat_id, "Кажется, вы не отправили фото.")
         chat
 
       {:error, _reason} ->
-        answer_on_message(key, chat_id, "Проблема с загрузкой фото")
+        answer_on_message(key, chat.chat_id, "Проблема с загрузкой фото")
         chat
     end
   end
 
-  defp handle_waiting_for_gallery_photos(key, update, chat, chat_id) do
+  defp handle_waiting_for_gallery_photos(key, update, chat) do
     text = get_in(update, ["message", "text"])
 
     if text == "Я закончил добавление фото" do
       next_step = make_next_step(:waiting_for_many_photos)
-      answer_on_message(key, chat_id, "Вы ввели данные:")
+      answer_on_message(key, chat.chat_id, "Вы ввели данные:")
       send_total(key, chat)
       %__MODULE__{chat | step: next_step}
     else
@@ -186,7 +186,7 @@ defmodule Botd.Chat do
           chat
 
         {:error, reason} ->
-          answer_on_message(key, chat_id, "Ошибка при обработке фото: #{reason}")
+          answer_on_message(key, chat.chat_id, "Ошибка при обработке фото: #{reason}")
           chat
       end
     end
@@ -211,7 +211,7 @@ defmodule Botd.Chat do
     end)
   end
 
-  defp handle_finished(key, update, chat, chat_id) do
+  defp handle_finished(key, update, chat) do
     username = get_user_name(update)
     text = get_in(update, ["message", "text"])
 
@@ -244,11 +244,11 @@ defmodule Botd.Chat do
 
         case Suggestions.create_suggestion(attributes, user) do
           {:ok, _suggestion} ->
-            answer_on_message(key, chat_id, "Данные успешно отправлены на модерацию!")
+            answer_on_message(key, chat.chat_id, "Данные успешно отправлены на модерацию!")
 
           {:error, changeset} ->
             Logger.error("Error creating suggestion: #{inspect(changeset)}")
-            answer_on_message(key, chat_id, "Ошибка при отправке данных.")
+            answer_on_message(key, chat.chat_id, "Ошибка при отправке данных.")
         end
 
         chat
@@ -258,7 +258,7 @@ defmodule Botd.Chat do
         %__MODULE__{chat | step: next_step}
 
       _ ->
-        answer_on_message(key, chat_id, "Действие в разработке")
+        answer_on_message(key, chat.chat_id, "Действие в разработке")
         chat
     end
   end
@@ -308,16 +308,16 @@ defmodule Botd.Chat do
     keyboard_markup
   end
 
-  def process_message_from_user(key, update, chat, chat_id) do
+  def process_message_from_user(key, update, chat) do
     handlers = %{
-      waiting_for_start: &handle_waiting_for_start/4,
-      selected_action: &handle_selected_action/4,
-      waiting_for_name: &handle_waiting_for_name/4,
-      waiting_for_death_date: &handle_waiting_for_death_date/4,
-      waiting_for_reason: &handle_waiting_for_reason/4,
-      waiting_for_photo: &handle_waiting_for_photo/4,
-      waiting_for_gallery_photos: &handle_waiting_for_gallery_photos/4,
-      finished: &handle_finished/4
+      waiting_for_start: &handle_waiting_for_start/3,
+      selected_action: &handle_selected_action/3,
+      waiting_for_name: &handle_waiting_for_name/3,
+      waiting_for_death_date: &handle_waiting_for_death_date/3,
+      waiting_for_reason: &handle_waiting_for_reason/3,
+      waiting_for_photo: &handle_waiting_for_photo/3,
+      waiting_for_gallery_photos: &handle_waiting_for_gallery_photos/3,
+      finished: &handle_finished/3
     }
 
     handler = Map.get(handlers, chat.step, &handle_unknown_state/1)
@@ -325,7 +325,7 @@ defmodule Botd.Chat do
     if handler == (&handle_unknown_state/1) do
       handler.(chat)
     else
-      handler.(key, update, chat, chat_id)
+      handler.(key, update, chat)
     end
   end
 

--- a/test/botd/chat_test.exs
+++ b/test/botd/chat_test.exs
@@ -162,6 +162,44 @@ defmodule ChatTest do
       assert result1.chat_id == chat1_id
       assert result2.chat_id == chat2_id
     end
+
+    test "handle_waiting_for_death_date with invalid date format", %{key: key} do
+      chat_id = 1
+      chat = %Chat{chat_id: chat_id, step: :waiting_for_death_date, name: "any", death_date: nil}
+
+      update =
+        TelegramMessagesFixture.create_message_fixture(
+          chat_id,
+          1_748_714_354,
+          1,
+          "Wrong-date",
+          54_321
+        )
+
+      result = Chat.process_message_from_user(key, update, chat)
+
+      assert result.step == :waiting_for_death_date
+      assert result.death_date == nil
+    end
+
+    test "handle_waiting_for_death_date with valid date format", %{key: key} do
+      chat_id = 1
+      chat = %Chat{chat_id: chat_id, step: :waiting_for_death_date, name: "any", death_date: nil}
+
+      update =
+        TelegramMessagesFixture.create_message_fixture(
+          chat_id,
+          1_748_714_354,
+          1,
+          "2025-05-11",
+          54_321
+        )
+
+      result = Chat.process_message_from_user(key, update, chat)
+
+      assert result.step == :waiting_for_reason
+      assert result.death_date == ~D[2025-05-11]
+    end
   end
 
   describe "make_photo_set from telegram update" do

--- a/test/botd/chat_test.exs
+++ b/test/botd/chat_test.exs
@@ -3,63 +3,62 @@ defmodule ChatTest do
   alias Botd.TelegramMessagesFixture
   use Botd.DataCase, async: true
 
-  describe "process_message_from_user/4" do
+  describe "process_message_from_user/3" do
     setup do
       key = "dummy_key"
-      chat_id = 12_345
-      {:ok, key: key, chat_id: chat_id}
+      {:ok, key: key}
     end
 
-    test "handles :waiting_for_start step", %{key: key, chat_id: chat_id} do
+    test "handles :waiting_for_start step", %{key: key} do
       chat = %Chat{step: :waiting_for_start}
       update = %{"message" => %{"text" => "/start"}}
 
-      result = Chat.process_message_from_user(key, update, chat, chat_id)
+      result = Chat.process_message_from_user(key, update, chat)
 
       assert result.step == :selected_action
     end
 
-    test "handles action", %{key: key, chat_id: chat_id} do
+    test "handles action", %{key: key} do
       chat = %Chat{step: :selected_action}
       update = %{"message" => %{"text" => "Добавить"}}
 
-      result = Chat.process_message_from_user(key, update, chat, chat_id)
+      result = Chat.process_message_from_user(key, update, chat)
 
       assert result.step == :waiting_for_name
     end
 
-    test "handles :waiting_for_name step", %{key: key, chat_id: chat_id} do
+    test "handles :waiting_for_name step", %{key: key} do
       chat = %Chat{step: :waiting_for_name, name: nil}
       update = %{"message" => %{"text" => "John Doe"}}
 
-      result = Chat.process_message_from_user(key, update, chat, chat_id)
+      result = Chat.process_message_from_user(key, update, chat)
 
       assert result.step == :waiting_for_death_date
       assert result.name == "John Doe"
     end
 
-    test "handles :waiting_for_death_date step", %{key: key, chat_id: chat_id} do
+    test "handles :waiting_for_death_date step", %{key: key} do
       chat = %Chat{step: :waiting_for_death_date, name: "any", death_date: nil}
       update = %{"message" => %{"text" => "2025-05-11"}}
 
-      result = Chat.process_message_from_user(key, update, chat, chat_id)
+      result = Chat.process_message_from_user(key, update, chat)
 
       assert result.step == :waiting_for_reason
       assert result.death_date == ~D[2025-05-11]
     end
 
-    test "handles :waiting_for_reason step", %{key: key, chat_id: chat_id} do
+    test "handles :waiting_for_reason step", %{key: key} do
       chat = %Chat{step: :waiting_for_reason, name: "any", death_date: "any", reason: "accident"}
       update = %{"message" => %{"text" => "Accident"}}
 
-      result = Chat.process_message_from_user(key, update, chat, chat_id)
+      result = Chat.process_message_from_user(key, update, chat)
 
       assert result.step == :waiting_for_photo
       assert result.reason == "Accident"
     end
 
     # This test require mocking. Looking for a solution / refactor
-    # test "handles :waiting_for_photo step", %{key: key, chat_id: chat_id} do
+    # test "handles :waiting_for_photo step", %{key: key} do
     #   chat = %Chat{
     #     step: :waiting_for_photo,
     #     name: "any",
@@ -80,17 +79,17 @@ defmodule ChatTest do
 
     #   update = %{"message" => %{"photo" => [%{"file_id" => "photo_id"}]}}
 
-    #   result = Chat.process_message_from_user(key, update, chat, chat_id)
+    #   result = Chat.process_message_from_user(key, update, chat)
 
     #   assert result.step == :finished
     #   assert result.photo_url == "test.jpg"
     # end
 
-    test "handles :finished state, will removed later", %{key: key, chat_id: chat_id} do
+    test "handles :finished state, will removed later", %{key: key} do
       chat = %Chat{step: :finished, name: "any", death_date: "any", reason: "any"}
       update = %{"message" => %{"text" => "Some text"}}
 
-      result = Chat.process_message_from_user(key, update, chat, chat_id)
+      result = Chat.process_message_from_user(key, update, chat)
 
       assert result == chat
       assert result.step == :finished
@@ -152,10 +151,10 @@ defmodule ChatTest do
         )
 
       result1 =
-        Chat.process_message_from_user(key, message1, chat1, chat1_id)
+        Chat.process_message_from_user(key, message1, chat1)
 
       result2 =
-        Chat.process_message_from_user(key, message2, chat2, chat2_id)
+        Chat.process_message_from_user(key, message2, chat2)
 
       assert result1.step == :waiting_for_death_date
       assert result2.step == :waiting_for_reason

--- a/test/support/fixtures/telegram_message_fixture.ex
+++ b/test/support/fixtures/telegram_message_fixture.ex
@@ -1,0 +1,72 @@
+defmodule Botd.TelegramMessagesFixture do
+  @moduledoc """
+  This module defines test helpers for creating
+  Telegram messages which are using in update struct for Botd.Chat.
+  """
+
+  def create_message_fixture(chat_id, date, message_id, text, update_id) do
+    %{
+      "message" => message(chat_id, date, message_id, text),
+      "update_id" => update_id
+    }
+  end
+
+  defp message(chat_id, date, message_id, text) do
+    %{
+      "chat" => chat(chat_id),
+      "date" => date,
+      "from" => from(chat_id),
+      "message_id" => message_id,
+      "text" => text
+    }
+  end
+
+  defp chat(chat_id) do
+    %{
+      "first_name" => "John",
+      "id" => chat_id,
+      "last_name" => "Doe",
+      "type" => "private",
+      "username" => "johndoe"
+    }
+  end
+
+  defp from(chat_id) do
+    %{
+      "first_name" => "John",
+      "id" => chat_id,
+      "is_bot" => false,
+      "is_premium" => true,
+      "language_code" => "en",
+      "last_name" => "Doe",
+      "username" => "johndoe"
+    }
+  end
+
+  def text_message_v2_1_0 do
+    %{
+      "message" => %{
+        "chat" => %{
+          "first_name" => "John",
+          "id" => 1,
+          "last_name" => "Doe",
+          "type" => "private",
+          "username" => "johndoe"
+        },
+        "date" => 1_748_714_354,
+        "from" => %{
+          "first_name" => "John",
+          "id" => 1,
+          "is_bot" => false,
+          "is_premium" => true,
+          "language_code" => "en",
+          "last_name" => "Doe",
+          "username" => "johndoe"
+        },
+        "message_id" => 1347,
+        "text" => "Some text message"
+      },
+      "update_id" => 597_970_970
+    }
+  end
+end


### PR DESCRIPTION
- create message fixture and test for 2 chats update
- remove extra argument for `chat_id`
- pattern matching for `text` in message 
- parsing date with error case

AI chat has issues to suggest me easy tests, but AI-inline help was good after I made a fixture function manually
