### PR TITLE
Test: add simple page render test for DS

### DIFF
--- a/test/botd_web/controllers/design_system_controller_test.exs
+++ b/test/botd_web/controllers/design_system_controller_test.exs
@@ -1,0 +1,32 @@
+defmodule BotdWeb.DesignSystemControllerTest do
+  use BotdWeb.ConnCase, async: true
+
+  describe "GET /design-system" do
+    test "renders the design system page", %{conn: conn} do
+      conn = get(conn, ~p"/design-system")
+      assert html_response(conn, 200) =~ "Spectral Archive"
+    end
+
+    test "renders all component sections", %{conn: conn} do
+      conn = get(conn, ~p"/design-system")
+      html = html_response(conn, 200)
+
+      assert html =~ "Back Link"
+      assert html =~ "Buttons"
+      assert html =~ "Cards & Surfaces"
+      assert html =~ "Colors"
+      assert html =~ "Effects"
+      assert html =~ "Flash"
+      assert html =~ "Header"
+      assert html =~ "Icons (Heroicons)"
+      assert html =~ "Inputs"
+      assert html =~ "List"
+      assert html =~ "Modal"
+      assert html =~ "Pagination"
+      assert html =~ "Person Card"
+      assert html =~ "Shadows"
+      assert html =~ "Table"
+      assert html =~ "Typography"
+    end
+  end
+end


### PR DESCRIPTION
Why this can be usefule?

First: if any component has new required attrs and this page unchanged - it will fails to load, the "page title" test catch it

Second: if any component will be renamed/removed and not synced in the design page, it will fail in "render all components" tests.

In other words, tests are pretty dummy, but will help to work with AI