### PR TITLE
Add: redesign people list

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -121,3 +121,7 @@
 @utility pixel-border-inset {
   box-shadow: inset 4px 4px 0px 0px rgba(51, 52, 61, 1);
 }
+
+@utility card-inset {
+  box-shadow: inset 4px 4px 0px 0px rgba(0, 0, 0, 0.3);
+}

--- a/lib/botd_web/components/layouts/app.html.heex
+++ b/lib/botd_web/components/layouts/app.html.heex
@@ -1,4 +1,4 @@
-<header class="fixed top-0 w-full z-50 flex items-center justify-between px-6 h-16 bg-background border-b-4 border-surface-container-high/50 shadow-[0_20px_50px_rgba(135,211,212,0.05)]">
+<header class="fixed top-0 w-full z-50 flex items-center justify-between px-6 h-16 bg-surface border-b-4 border-surface-container-high/50 shadow-[0_20px_50px_rgba(135,211,212,0.05)]">
   <.link href={~p"/people"} class="flex items-center gap-3">
     <.icon name="hero-book-open-solid" class="w-6 h-6 text-primary" />
     <span class="font-headline uppercase tracking-widest font-bold text-xl text-primary">

--- a/lib/botd_web/components/layouts/app.html.heex
+++ b/lib/botd_web/components/layouts/app.html.heex
@@ -1,12 +1,12 @@
-<header class="flex justify-center items-center h-16 text-base">
-  <.link href={~p"/people"}>
-    <.icon name="hero-user-group-solid" />
-    <span class="pl-2">Book of the dead</span>
+<header class="fixed top-0 w-full z-50 flex items-center justify-between px-6 h-16 bg-background border-b-4 border-surface-container-high/50 shadow-[0_20px_50px_rgba(135,211,212,0.05)]">
+  <.link href={~p"/people"} class="flex items-center gap-3">
+    <.icon name="hero-book-open-solid" class="w-6 h-6 text-primary" />
+    <span class="font-headline uppercase tracking-widest font-bold text-xl text-primary">
+      Book of the Dead
+    </span>
   </.link>
 </header>
-<main>
-  <div class="mx-auto">
-    <.flash_group flash={@flash} />
-    {@inner_content}
-  </div>
+<main class="pt-24 pb-16 px-6 max-w-7xl mx-auto">
+  <.flash_group flash={@flash} />
+  {@inner_content}
 </main>

--- a/lib/botd_web/components/person_card.ex
+++ b/lib/botd_web/components/person_card.ex
@@ -9,27 +9,53 @@ defmodule BotdWeb.PersonCard do
 
   def person_card(assigns) do
     ~H"""
-    <.link href={"/people/#{@person.id}"}>
-      <div class="flex items-center m-4">
-        <%= if @person.photo_url do %>
-          <img
-            src={@person.photo_url}
-            alt={@person.name}
-            class="w-20 h-20 object-cover rounded-full border border-outline-variant mr-6"
-          />
-        <% else %>
-          <.icon name="hero-camera" class="w-20 h-20 text-outline mr-6" />
-        <% end %>
-        <div class="flex-1">
-          <div class="text-xl mb-1">{@person.name}</div>
-          <div class="text-on-surface-variant text-xs mb-1 font-light">
-            {@person.birth_date} - {@person.death_date}
+    <.link href={"/people/#{@person.id}"} class="block">
+      <article class="group relative bg-surface-container-low p-6 transition-all duration-300 hover:-translate-y-1 hover:bg-surface-container">
+        <div class="absolute inset-0 dither-pattern opacity-10 pointer-events-none"></div>
+        <div class="relative flex flex-col h-full">
+          <div class="flex items-start gap-4 mb-6">
+            <div class="w-20 h-20 bg-surface-container-highest flex-shrink-0 card-inset overflow-hidden flex items-center justify-center border-2 border-outline-variant/30">
+              <%= if @person.photo_url do %>
+                <img
+                  src={@person.photo_url}
+                  alt={@person.name}
+                  class="w-full h-full object-cover grayscale contrast-125 mix-blend-screen opacity-70"
+                />
+              <% else %>
+                <.icon name="hero-camera" class="w-10 h-10 text-outline" />
+              <% end %>
+            </div>
+            <div class="flex-grow">
+              <h3 class="font-headline font-bold text-2xl text-on-surface leading-tight mb-1 group-hover:text-primary transition-colors uppercase">
+                {@person.name}
+              </h3>
+              <p class="font-label text-secondary text-sm tracking-widest">
+                {@person.birth_date} — {@person.death_date}
+              </p>
+            </div>
           </div>
-          <div class="text-on-surface-variant text-xs mb-2">
-            Несколько слов из description. Полный текст можно прочитать на странице человека. Здесь три строчки текста.
+          <div class="space-y-4">
+            <%= if @person.description do %>
+              <p class="text-on-surface-variant leading-relaxed text-sm line-clamp-3">
+                {@person.description}
+              </p>
+            <% end %>
+            <%= if @person.place do %>
+              <div class="pt-4 border-t border-outline-variant/30 flex justify-between items-center">
+                <span class="inline-block px-3 py-1 bg-primary-container text-primary text-[10px] font-label uppercase tracking-widest">
+                  {@person.place}
+                </span>
+                <.icon
+                  name="hero-archive-box"
+                  class="w-5 h-5 text-outline group-hover:text-primary transition-colors"
+                />
+              </div>
+            <% end %>
           </div>
         </div>
-      </div>
+        <div class="absolute -bottom-1 -right-1 w-4 h-4 bg-primary opacity-0 group-hover:opacity-100 transition-opacity">
+        </div>
+      </article>
     </.link>
     """
   end

--- a/lib/botd_web/controllers/design_system_html/index.html.heex
+++ b/lib/botd_web/controllers/design_system_html/index.html.heex
@@ -427,7 +427,10 @@
             name: "Aleksei Petrov",
             birth_date: "1923-03-12",
             death_date: "1998-11-05",
-            photo_url: nil
+            photo_url: nil,
+            description:
+              "A devoted archivist who spent forty years preserving spoken histories in the Southern District.",
+            place: "Moscow"
           }
         } />
       </div>

--- a/lib/botd_web/controllers/person_controller.ex
+++ b/lib/botd_web/controllers/person_controller.ex
@@ -12,13 +12,19 @@ defmodule BotdWeb.PersonController do
     {page, _} = Integer.parse(page)
     {per_page, _} = Integer.parse(per_page)
 
-    %{entries: people, page_number: page_number, total_pages: total_pages} =
+    %{
+      entries: people,
+      page_number: page_number,
+      total_pages: total_pages,
+      total_entries: total_entries
+    } =
       People.list_people(page: page, per_page: per_page, search: search)
 
     render(conn, :index,
       people: people,
       page_number: page_number,
       total_pages: total_pages,
+      total_entries: total_entries,
       per_page: per_page,
       search: search
     )

--- a/lib/botd_web/controllers/person_html/index.html.heex
+++ b/lib/botd_web/controllers/person_html/index.html.heex
@@ -1,5 +1,3 @@
-<.flash_group flash={@flash} />
-
 <section class="mb-12">
   <form method="get" action={~p"/people"} class="w-full">
     <div class="relative group">

--- a/lib/botd_web/controllers/person_html/index.html.heex
+++ b/lib/botd_web/controllers/person_html/index.html.heex
@@ -1,34 +1,66 @@
 <.flash_group flash={@flash} />
 
-<form method="get" action={~p"/people"} class="w-full mb-6">
-  <div class="relative m-2 mr-4 ml-4">
-    <span class="absolute inset-y-0 left-0 flex items-center pl-3">
-      <!-- Heroicons Magnifying Glass SVG -->
-      <svg
-        class="h-5 w-5 text-outline"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        viewBox="0 0 24 24"
-      >
-        <circle cx="11" cy="11" r="8" stroke="currentColor" stroke-width="2" fill="none" />
-        <line x1="21" y1="21" x2="16.65" y2="16.65" stroke="currentColor" stroke-width="2" />
-      </svg>
-    </span>
-    <input
-      type="text"
-      name="search"
-      value={@search}
-      placeholder="Search by name"
-      class="block w-full pl-10 pr-4 py-2 bg-surface-container border border-outline-variant text-on-surface placeholder-outline focus:border-primary focus:ring-1 focus:ring-primary"
-    />
-  </div>
-</form>
+<section class="mb-12">
+  <form method="get" action={~p"/people"} class="w-full">
+    <div class="relative group">
+      <div class="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
+        <.icon name="hero-magnifying-glass" class="w-6 h-6 text-primary" />
+      </div>
+      <input
+        type="text"
+        name="search"
+        value={@search}
+        placeholder="SEARCH THE DEPARTED..."
+        class="w-full bg-surface-container-lowest border-none focus:ring-2 focus:ring-primary text-on-surface placeholder:text-outline font-headline tracking-widest py-5 pl-14 uppercase text-lg"
+      />
+      <div class="absolute bottom-0 left-0 w-full h-1 bg-primary/20 group-focus-within:bg-primary transition-colors">
+      </div>
+    </div>
+  </form>
+</section>
 
-<div class="grid gap-2 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+<header class="mb-10 flex flex-col md:flex-row md:items-end justify-between gap-6">
+  <div>
+    <h2 class="text-5xl md:text-7xl font-headline font-bold text-on-surface leading-none tracking-tighter">
+      BOOK OF THE DEAD
+    </h2>
+  </div>
+  <div class="bg-surface-container-low p-4 flex gap-8 items-center border-l-4 border-secondary">
+    <div>
+      <p class="text-[10px] text-outline uppercase tracking-widest font-label">
+        Archived Entries
+      </p>
+      <p class="text-2xl font-headline font-bold text-secondary">
+        {@total_entries}
+      </p>
+    </div>
+    <div>
+      <p class="text-[10px] text-outline uppercase tracking-widest font-label">Last Updated</p>
+      <p class="text-2xl font-headline font-bold text-primary">
+        <%= case List.first(@people) do %>
+          <% nil -> %>
+            —
+          <% person -> %>
+            {Calendar.strftime(person.updated_at, "%d.%m.%y")}
+        <% end %>
+      </p>
+    </div>
+  </div>
+</header>
+
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10">
   <%= for person <- @people do %>
     <.person_card person={person} />
   <% end %>
+
+  <.link href={~p"/people/new"} class="block">
+    <article class="group relative bg-surface-container-low p-6 transition-all duration-300 hover:-translate-y-1 border-2 border-dashed border-outline-variant/50 flex items-center justify-center min-h-[200px]">
+      <div class="text-center">
+        <.icon name="hero-pencil-square" class="w-10 h-10 text-outline mb-4 mx-auto" />
+        <p class="font-headline font-bold text-lg text-outline">SUGGEST AN ENTRY</p>
+      </div>
+    </article>
+  </.link>
 </div>
 
 <.pagination

--- a/lib/botd_web/controllers/person_html/index.html.heex
+++ b/lib/botd_web/controllers/person_html/index.html.heex
@@ -18,11 +18,6 @@
 </section>
 
 <header class="mb-10 flex flex-col md:flex-row md:items-end justify-between gap-6">
-  <div>
-    <h2 class="text-5xl md:text-7xl font-headline font-bold text-on-surface leading-none tracking-tighter">
-      BOOK OF THE DEAD
-    </h2>
-  </div>
   <div class="bg-surface-container-low p-4 flex gap-8 items-center border-l-4 border-secondary">
     <div>
       <p class="text-[10px] text-outline uppercase tracking-widest font-label">


### PR DESCRIPTION
Redesign people list with new design from Stitch, prompt was:

```
This is index page for the person list. 

Let's adapt new design from this page. I have a design instruction for you below:

## Stitch Instructions

Get the images and code for the following Stitch project's screens:

## Project
Title: Botd only
ID: <project_id>

## Screens:
1. Memorial List (Pixel)
    ID: <element_id>

Use a utility like `curl -L` to download the hosted URLs.

---

When you will work with it, you can notice different items. Ask me question how to map them to our current project
```

![Screenshot 2026-03-24 at 15 10 46](https://github.com/user-attachments/assets/33953866-8b65-4fad-8216-8d8cdeabbb83)

Does not work from first prompt: padding around elements in general. Questions was nice, and footer was decoupled from planning. Next pr will be about add the footer.